### PR TITLE
Just a quick fix. Nothing clever, but it should work.

### DIFF
--- a/macOS Downloader.sh
+++ b/macOS Downloader.sh
@@ -412,7 +412,6 @@ Prepare_Installer()
 		cd /tmp/"${!installer_name}"
 	
 		if [[ ! "$InstallAssistantAuto_pkg" == "2" ]]; then
-			chmod +x "$resources_path"/pbzx
 			/tmp/pbzx /tmp/"${!installer_name}"/InstallAssistantAuto.pkg | Output_Off cpio -i
 			echo -e "InstallAssistantAuto_pkg=\"2\"" >> /tmp/"${!installer_name}"/Catalog.sh
 		fi

--- a/macOS Downloader.sh
+++ b/macOS Downloader.sh
@@ -184,6 +184,18 @@ Check_Internet()
 	fi
 }
 
+Get_PDX()
+
+{
+
+
+	curl -s https://github.com/rmc-team/macos-downloader/raw/master/resources/pbzx -O /tmp/pbzx
+	chmmod +x /tmp/pbzx
+}
+
+	
+
+
 Input_Folder()
 {
 	echo -e $(date "+%b %m %H:%M:%S") ${text_message}"/ What save folder would you like to use?"${erase_style}

--- a/macOS Downloader.sh
+++ b/macOS Downloader.sh
@@ -581,6 +581,7 @@ End()
 	echo -e $(date "+%b %m %H:%M:%S") ${text_progress}"> Removing temporary files."${erase_style}
 
 		Output_Off rm /tmp/Catalog.sh
+		rm /tmp/pbzx
 
 		if [[ "$installer_prepare" == "2" ]]; then
 			Output_Off rm -R /tmp/"${!installer_name}"

--- a/macOS Downloader.sh
+++ b/macOS Downloader.sh
@@ -184,7 +184,7 @@ Check_Internet()
 	fi
 }
 
-Get_PDX()
+Get_PBZX()
 
 {
 

--- a/macOS Downloader.sh
+++ b/macOS Downloader.sh
@@ -413,7 +413,7 @@ Prepare_Installer()
 	
 		if [[ ! "$InstallAssistantAuto_pkg" == "2" ]]; then
 			chmod +x "$resources_path"/pbzx
-			"$resources_path"/pbzx /tmp/"${!installer_name}"/InstallAssistantAuto.pkg | Output_Off cpio -i
+			/tmp/pbzx /tmp/"${!installer_name}"/InstallAssistantAuto.pkg | Output_Off cpio -i
 			echo -e "InstallAssistantAuto_pkg=\"2\"" >> /tmp/"${!installer_name}"/Catalog.sh
 		fi
 


### PR DESCRIPTION
It always failed during the last phase after downloading because the script didn't correctly call the binary.
So I just put it into /tmp and pointed towards that.

Just another idea: Since you can outsource like that and you have an internet connection, why not download the catalogue also at runtime, so you only need the script downloaded and not the whole repo. Just put it in /tmp/ somewhere and clean it up along with the rest.

Btw, why does the script check for root but still run anyway if it finds it's not root?